### PR TITLE
Create GitHub workflow to manage PR labels automatically

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,75 @@
+name: labeler
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Label
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const typeLabels = [
+              'feat',
+              'fix',
+              'perf',
+              'docs',
+              'test',
+              'refactor',
+              'style',
+              'build',
+              'ci',
+              'revert',
+              'chore',
+            ];
+            const repoLabels = [...typeLabels, 'BREAKING CHANGE'];
+            const prBody = context.payload.pull_request.body;
+            const prLabels = (
+              await github.rest.issues.listLabelsOnIssue({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              })
+            ).map((label) => label.name);
+            const prTypeLabels = [];
+            for (const label of repoLabels) {
+              if (prBody.includes(`[x] ${label}: `)) {
+                if (!prLabels.includes(label)) {
+                  await github.rest.issues.addLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: context.issue.number,
+                    name: label,
+                  });
+                }
+                if (typeLabels.includes(label)) {
+                  prTypeLabels.push(label);
+                }
+              } else if (prLabels.includes(label)) {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  name: label,
+                });
+              }
+            }
+            if (prTypeLabels.length !== 1) {
+              core.setFailed(
+                `One and only one type label must be set, tried [${prTypeLabels.join(', ')}]`,
+              );
+            }


### PR DESCRIPTION
## Type of change

- [ ] feat: New feature
- [ ] fix: Bug fix
- [ ] perf: Performance improvement
- [ ] docs: Documentation
- [ ] test: Testing
- [ ] refactor: Code refactor
- [ ] style: Code style
- [ ] build: Build
- [x] ci: CI
- [ ] revert: Revert
- [ ] chore: Release

## Breaking changes

- [ ] BREAKING CHANGE: This pull request introduces breaking changes.

## Description

Create GitHub workflow to manage PR labels automatically.

## Related tickets and documents

None.

## QA instructions

None.

## Actions

- [x] Skip linter.
- [x] Skip build.
- [x] Skip test.
- [ ] Skip code analysis.

## Checklist

### Pull request title

- [x] The **pull request title** describes the change well.

> Pull request titles are used to generate automatic release notes so well written titles help document each version.

### Pull request labels

- [ ] The **pull request label(s)** are set and the `BREAKING CHANGE` one is present if needed.

> Pull request labels are used to categorise the changes when generating automatic release notes; breaking changes are included in an individual category to help identify them.

### Squash commit

- [ ] The **squash commit** follows the [Conventional commits specification](https://www.conventionalcommits.org).

> Conventional commits are used to identify which should be the next version and so automate the release process; breaking changes must be included in the commit footer following the specification.
